### PR TITLE
Add Google Analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,5 +17,12 @@ module.exports = {
       },
     },
     "gatsby-plugin-mdx",
+    {
+      resolve: `gatsby-plugin-google-gtag`,
+      options: {
+        // You can add multiple tracking ids and a pageview event will be fired for all of them.
+        trackingIds: ["G-SFGDK8KTE9"],
+      },
+    },
   ],
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/react-dom": "^17.0.11",
     "@types/smooth-scroll": "^16.1.1",
     "gatsby": "^4.4.0",
+    "gatsby-plugin-google-gtag": "^4.18.0",
     "gatsby-plugin-graphql-codegen": "^3.1.0",
     "gatsby-plugin-image": "^2.5.1",
     "gatsby-plugin-mdx": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6645,6 +6645,14 @@ gatsby-parcel-config@^0.7.0:
     "@parcel/transformer-raw" "2.6.0"
     "@parcel/transformer-react-refresh-wrap" "2.6.0"
 
+gatsby-plugin-google-gtag@^4.18.0:
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-4.18.0.tgz#b06adf0a57661694c41e3b748936a1a6f521f7bc"
+  integrity sha512-oLIFmndlvmPyMlDR2z0NkTyTg05VLIi6vYlCUiqOaf1AOQKkmV9UxX0pwCDGuKxQPGIY3n8UkhkSqERIvQL2Dw==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    minimatch "^3.1.2"
+
 gatsby-plugin-graphql-codegen@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-graphql-codegen/-/gatsby-plugin-graphql-codegen-3.1.1.tgz#346c29a28d0eec37ed74a1c6686df65898cd34aa"


### PR DESCRIPTION
This uses https://www.gatsbyjs.com/plugins/gatsby-plugin-google-gtag/?=google%20analytics to add Google Analytics tracking to the personal website.

Not sure how to test as this only works in production.